### PR TITLE
chore: actualizar cadenas de conexión RecruitAI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+charset = utf-8-bom
+end_of_line = lf
+insert_final_newline = true
+
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:suggestion
+
+csharp_prefer_braces = true:warning
+csharp_new_line_before_open_brace = all
+
+[*.{csproj,sln}]
+charset = utf-8
+indent_size = 2
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Archivos de compilación
+bin/
+obj/
+**/bin/
+**/obj/
+
+# Herramientas
+.vs/
+.idea/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# VSCode
+.vscode/
+
+# Sistema operativo
+.DS_Store
+Thumbs.db
+
+# Paquetes
+packages/
+*.nupkg
+
+# Logs
+*.log
+
+# Secretos
+secrets.json
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# api-rrhh
+# RecruitAI
+
+Solución .NET 8 por capas para gestionar procesos de reclutamiento con soporte para embeddings de OpenAI y coincidencias basadas en similitud de vectores.
+
+## Estructura
+
+```
+RecruitAI/
+├─ RecruitAI.sln
+├─ src/
+│  ├─ RecruitAI.Web/
+│  ├─ RecruitAI.Contratos/
+│  ├─ RecruitAI.Datos/
+│  └─ RecruitAI.Servicios/
+└─ tests/
+   └─ RecruitAI.Tests/
+```
+
+## Prerrequisitos
+
+* .NET SDK 8.0
+* SQL Server (local o remoto) accesible mediante las cadenas de conexión configuradas.
+
+## Configuración
+
+Actualiza las cadenas de conexión y secretos en `src/RecruitAI.Web/appsettings.json` o mediante variables de entorno:
+
+```json
+{
+  "ConnectionStrings": {
+    "RecruitAIConexionCompleta": "Server=DESKTOP-8L1PQ7F;Database=RecruitAI;Trusted_Connection=True;TrustServerCertificate=True;",
+    "RecruitAIConexionSoloLectura": "Server=DESKTOP-8L1PQ7F;Database=RecruitAI;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
+  "OpenAI": {
+    "ApiKey": "sk-xxxx"
+  },
+  "Jwt": {
+    "Emisor": "http://localhost",
+    "Audiencia": "http://localhost",
+    "Secreto": "cambialo-porfavor"
+  }
+}
+```
+
+Variables recomendadas:
+
+* `ConnectionStrings__RecruitAIConexionCompleta`
+* `ConnectionStrings__RecruitAIConexionSoloLectura`
+* `OpenAI__ApiKey`
+* `Jwt__Emisor`
+* `Jwt__Audiencia`
+* `Jwt__Secreto`
+
+## Comandos útiles
+
+```bash
+# Compilar la solución completa
+dotnet build
+
+# Crear una migración inicial
+dotnet ef migrations add Init --project src/RecruitAI.Datos --startup-project src/RecruitAI.Web
+
+# Aplicar las migraciones
+dotnet ef database update --project src/RecruitAI.Datos --startup-project src/RecruitAI.Web
+
+# Ejecutar la API
+dotnet run --project src/RecruitAI.Web
+```
+
+## Endpoints principales
+
+* `GET /api/puestos` — Lista de puestos utilizando la base de solo lectura.
+* `GET /api/candidatos` — Lista de candidatos utilizando la base de solo lectura.
+* `POST /api/coincidencias/puestos/{puestoId}/embedding` — Genera y persiste el embedding del puesto.
+* `POST /api/coincidencias/candidatos/{candidatoId}/embedding` — Genera y persiste el embedding del candidato.
+* `GET /api/coincidencias/puestos/{puestoId}/top?cantidad=20&umbral=0.65` — Obtiene coincidencias ordenadas descendentemente por puntaje.
+
+Swagger incluye soporte para autenticación JWT (pendiente de habilitar). FluentValidation valida automáticamente los DTOs de entrada.
+
+## Siguientes pasos
+
+* Implementar el servicio de IA para extracción y puntuación real usando OpenAI.
+* Completar flujo de autenticación JWT y autorización por roles.
+* Agregar más pruebas unitarias e integración.
+* Automatizar despliegue continuo y parametrizar las conexiones de lectura y escritura.

--- a/RecruitAI.sln
+++ b/RecruitAI.sln
@@ -1,0 +1,45 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecruitAI.Web", "src/RecruitAI.Web/RecruitAI.Web.csproj", "{75FCF68D-0BBC-4A3E-8EF4-933E0D8F4D1E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecruitAI.Contratos", "src/RecruitAI.Contratos/RecruitAI.Contratos.csproj", "{E78395BB-5BE1-4CF7-B60D-B4D0AB20FFE3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecruitAI.Datos", "src/RecruitAI.Datos/RecruitAI.Datos.csproj", "{C1F51C6A-84F2-47DF-8910-672DF54FC19A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecruitAI.Servicios", "src/RecruitAI.Servicios/RecruitAI.Servicios.csproj", "{F40536D1-CF3D-419B-AC5C-01126BF10978}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RecruitAI.Tests", "tests/RecruitAI.Tests/RecruitAI.Tests.csproj", "{8A85B7B7-9A16-4E4C-A396-893D96DAA611}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{75FCF68D-0BBC-4A3E-8EF4-933E0D8F4D1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{75FCF68D-0BBC-4A3E-8EF4-933E0D8F4D1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{75FCF68D-0BBC-4A3E-8EF4-933E0D8F4D1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{75FCF68D-0BBC-4A3E-8EF4-933E0D8F4D1E}.Release|Any CPU.Build.0 = Release|Any CPU
+{E78395BB-5BE1-4CF7-B60D-B4D0AB20FFE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{E78395BB-5BE1-4CF7-B60D-B4D0AB20FFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{E78395BB-5BE1-4CF7-B60D-B4D0AB20FFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{E78395BB-5BE1-4CF7-B60D-B4D0AB20FFE3}.Release|Any CPU.Build.0 = Release|Any CPU
+{C1F51C6A-84F2-47DF-8910-672DF54FC19A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{C1F51C6A-84F2-47DF-8910-672DF54FC19A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{C1F51C6A-84F2-47DF-8910-672DF54FC19A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{C1F51C6A-84F2-47DF-8910-672DF54FC19A}.Release|Any CPU.Build.0 = Release|Any CPU
+{F40536D1-CF3D-419B-AC5C-01126BF10978}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{F40536D1-CF3D-419B-AC5C-01126BF10978}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{F40536D1-CF3D-419B-AC5C-01126BF10978}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{F40536D1-CF3D-419B-AC5C-01126BF10978}.Release|Any CPU.Build.0 = Release|Any CPU
+{8A85B7B7-9A16-4E4C-A396-893D96DAA611}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{8A85B7B7-9A16-4E4C-A396-893D96DAA611}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{8A85B7B7-9A16-4E4C-A396-893D96DAA611}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{8A85B7B7-9A16-4E4C-A396-893D96DAA611}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/RecruitAI.Contratos/Dtos/Candidatos/CandidatoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Candidatos/CandidatoDto.cs
@@ -1,0 +1,11 @@
+namespace RecruitAI.Contratos.Dtos.Candidatos;
+
+public class CandidatoDto
+{
+    public Guid Id { get; set; }
+    public string NombreCompleto { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Fuente { get; set; }
+    public string CvTexto { get; set; } = string.Empty;
+    public DateTime CreadoEl { get; set; }
+}

--- a/src/RecruitAI.Contratos/Dtos/Candidatos/CrearCandidatoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Candidatos/CrearCandidatoDto.cs
@@ -1,0 +1,9 @@
+namespace RecruitAI.Contratos.Dtos.Candidatos;
+
+public class CrearCandidatoDto
+{
+    public string NombreCompleto { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Fuente { get; set; }
+    public string CvTexto { get; set; } = string.Empty;
+}

--- a/src/RecruitAI.Contratos/Dtos/Candidatos/EditarCandidatoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Candidatos/EditarCandidatoDto.cs
@@ -1,0 +1,9 @@
+namespace RecruitAI.Contratos.Dtos.Candidatos;
+
+public class EditarCandidatoDto
+{
+    public string NombreCompleto { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Fuente { get; set; }
+    public string CvTexto { get; set; } = string.Empty;
+}

--- a/src/RecruitAI.Contratos/Dtos/Coincidencias/CoincidenciaDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Coincidencias/CoincidenciaDto.cs
@@ -1,0 +1,9 @@
+namespace RecruitAI.Contratos.Dtos.Coincidencias;
+
+public class CoincidenciaDto
+{
+    public Guid CandidatoId { get; set; }
+    public string NombreCompleto { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public double Puntaje { get; set; }
+}

--- a/src/RecruitAI.Contratos/Dtos/Coincidencias/TopCoincidenciasRequest.cs
+++ b/src/RecruitAI.Contratos/Dtos/Coincidencias/TopCoincidenciasRequest.cs
@@ -1,0 +1,7 @@
+namespace RecruitAI.Contratos.Dtos.Coincidencias;
+
+public class TopCoincidenciasRequest
+{
+    public int Cantidad { get; set; } = 20;
+    public double? Umbral { get; set; }
+}

--- a/src/RecruitAI.Contratos/Dtos/Ia/ExtraerCvRequest.cs
+++ b/src/RecruitAI.Contratos/Dtos/Ia/ExtraerCvRequest.cs
@@ -1,0 +1,6 @@
+namespace RecruitAI.Contratos.Dtos.Ia;
+
+public class ExtraerCvRequest
+{
+    public string CvTexto { get; set; } = string.Empty;
+}

--- a/src/RecruitAI.Contratos/Dtos/Ia/PuntuarRequest.cs
+++ b/src/RecruitAI.Contratos/Dtos/Ia/PuntuarRequest.cs
@@ -1,0 +1,7 @@
+namespace RecruitAI.Contratos.Dtos.Ia;
+
+public class PuntuarRequest
+{
+    public string CvTexto { get; set; } = string.Empty;
+    public string DescripcionPuesto { get; set; } = string.Empty;
+}

--- a/src/RecruitAI.Contratos/Dtos/Puestos/CrearPuestoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Puestos/CrearPuestoDto.cs
@@ -1,0 +1,10 @@
+namespace RecruitAI.Contratos.Dtos.Puestos;
+
+public class CrearPuestoDto
+{
+    public string Titulo { get; set; } = string.Empty;
+    public string Descripcion { get; set; } = string.Empty;
+    public string? Seniority { get; set; }
+    public string? Ubicacion { get; set; }
+    public List<string> HabilidadesRequeridas { get; set; } = new();
+}

--- a/src/RecruitAI.Contratos/Dtos/Puestos/EditarPuestoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Puestos/EditarPuestoDto.cs
@@ -1,0 +1,10 @@
+namespace RecruitAI.Contratos.Dtos.Puestos;
+
+public class EditarPuestoDto
+{
+    public string Titulo { get; set; } = string.Empty;
+    public string Descripcion { get; set; } = string.Empty;
+    public string? Seniority { get; set; }
+    public string? Ubicacion { get; set; }
+    public List<string> HabilidadesRequeridas { get; set; } = new();
+}

--- a/src/RecruitAI.Contratos/Dtos/Puestos/PuestoDto.cs
+++ b/src/RecruitAI.Contratos/Dtos/Puestos/PuestoDto.cs
@@ -1,0 +1,12 @@
+namespace RecruitAI.Contratos.Dtos.Puestos;
+
+public class PuestoDto
+{
+    public Guid Id { get; set; }
+    public string Titulo { get; set; } = string.Empty;
+    public string Descripcion { get; set; } = string.Empty;
+    public string? Seniority { get; set; }
+    public string? Ubicacion { get; set; }
+    public IReadOnlyCollection<string> HabilidadesRequeridas { get; set; } = Array.Empty<string>();
+    public DateTime CreadoEl { get; set; }
+}

--- a/src/RecruitAI.Contratos/Entidades/ICandidatoEntidad.cs
+++ b/src/RecruitAI.Contratos/Entidades/ICandidatoEntidad.cs
@@ -1,0 +1,11 @@
+namespace RecruitAI.Contratos.Entidades;
+
+public interface ICandidatoEntidad
+{
+    Guid Id { get; }
+    string NombreCompleto { get; }
+    string Email { get; }
+    string? Fuente { get; }
+    string CvTexto { get; }
+    DateTime CreadoEl { get; }
+}

--- a/src/RecruitAI.Contratos/Entidades/IEmbeddingEntidad.cs
+++ b/src/RecruitAI.Contratos/Entidades/IEmbeddingEntidad.cs
@@ -1,0 +1,8 @@
+namespace RecruitAI.Contratos.Entidades;
+
+public interface IEmbeddingEntidad
+{
+    byte[]? Vector { get; }
+    string Modelo { get; }
+    DateTime ActualizadoEl { get; }
+}

--- a/src/RecruitAI.Contratos/Entidades/IPuestoEntidad.cs
+++ b/src/RecruitAI.Contratos/Entidades/IPuestoEntidad.cs
@@ -1,0 +1,12 @@
+namespace RecruitAI.Contratos.Entidades;
+
+public interface IPuestoEntidad
+{
+    Guid Id { get; }
+    string Titulo { get; }
+    string Descripcion { get; }
+    string? Seniority { get; }
+    string? Ubicacion { get; }
+    string? HabilidadesRequeridasJson { get; }
+    DateTime CreadoEl { get; }
+}

--- a/src/RecruitAI.Contratos/Interfaces/Repositorios/ICandidatoRepositorio.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Repositorios/ICandidatoRepositorio.cs
@@ -1,0 +1,9 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Contratos.Interfaces.Repositorios;
+
+public interface ICandidatoRepositorio : IRepositorioGenerico<ICandidatoEntidad>
+{
+    Task<ICandidatoEntidad?> ObtenerConEmbeddingAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<List<ICandidatoEntidad>> ListarConEmbeddingAsync(CancellationToken cancellationToken = default);
+}

--- a/src/RecruitAI.Contratos/Interfaces/Repositorios/IPuestoRepositorio.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Repositorios/IPuestoRepositorio.cs
@@ -1,0 +1,8 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Contratos.Interfaces.Repositorios;
+
+public interface IPuestoRepositorio : IRepositorioGenerico<IPuestoEntidad>
+{
+    Task<IPuestoEntidad?> ObtenerConEmbeddingAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/RecruitAI.Contratos/Interfaces/Repositorios/IRepositorioGenerico.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Repositorios/IRepositorioGenerico.cs
@@ -1,0 +1,11 @@
+namespace RecruitAI.Contratos.Interfaces.Repositorios;
+
+public interface IRepositorioGenerico<T>
+{
+    Task<T?> ObtenerPorIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<List<T>> ListarAsync(CancellationToken cancellationToken = default);
+    Task AgregarAsync(T entidad, CancellationToken cancellationToken = default);
+    Task ActualizarAsync(T entidad, CancellationToken cancellationToken = default);
+    Task EliminarAsync(T entidad, CancellationToken cancellationToken = default);
+    Task GuardarCambiosAsync(CancellationToken cancellationToken = default);
+}

--- a/src/RecruitAI.Contratos/Interfaces/Servicios/ICoincidenciasServicio.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Servicios/ICoincidenciasServicio.cs
@@ -1,0 +1,8 @@
+using RecruitAI.Contratos.Dtos.Coincidencias;
+
+namespace RecruitAI.Contratos.Interfaces.Servicios;
+
+public interface ICoincidenciasServicio
+{
+    Task<IReadOnlyCollection<CoincidenciaDto>> TopPorPuestoAsync(Guid puestoId, int cantidad = 20, double? umbral = null, CancellationToken cancellationToken = default);
+}

--- a/src/RecruitAI.Contratos/Interfaces/Servicios/IEmbeddingsServicio.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Servicios/IEmbeddingsServicio.cs
@@ -1,0 +1,8 @@
+namespace RecruitAI.Contratos.Interfaces.Servicios;
+
+public interface IEmbeddingsServicio
+{
+    Task<float[]> GenerarEmbeddingAsync(string texto, string modelo = "text-embedding-3-large", CancellationToken cancellationToken = default);
+    byte[] ConvertirABytes(float[] vector);
+    float[] ConvertirAFlotantes(byte[] datos);
+}

--- a/src/RecruitAI.Contratos/Interfaces/Servicios/IIaServicio.cs
+++ b/src/RecruitAI.Contratos/Interfaces/Servicios/IIaServicio.cs
@@ -1,0 +1,9 @@
+using RecruitAI.Contratos.Dtos.Ia;
+
+namespace RecruitAI.Contratos.Interfaces.Servicios;
+
+public interface IIaServicio
+{
+    Task<string> ExtraerCvAsync(ExtraerCvRequest request, CancellationToken cancellationToken = default);
+    Task<double> PuntuarAsync(PuntuarRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/RecruitAI.Contratos/RecruitAI.Contratos.csproj
+++ b/src/RecruitAI.Contratos/RecruitAI.Contratos.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.8.0" />
+  </ItemGroup>
+</Project>

--- a/src/RecruitAI.Contratos/Validaciones/Candidatos/CrearCandidatoValidador.cs
+++ b/src/RecruitAI.Contratos/Validaciones/Candidatos/CrearCandidatoValidador.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using RecruitAI.Contratos.Dtos.Candidatos;
+
+namespace RecruitAI.Contratos.Validaciones.Candidatos;
+
+public class CrearCandidatoValidador : AbstractValidator<CrearCandidatoDto>
+{
+    public CrearCandidatoValidador()
+    {
+        RuleFor(x => x.NombreCompleto)
+            .NotEmpty().WithMessage("El nombre completo es obligatorio.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("El correo es obligatorio.")
+            .EmailAddress().WithMessage("El correo debe tener un formato válido.");
+
+        RuleFor(x => x.CvTexto)
+            .NotEmpty().WithMessage("El CV no puede estar vacío.");
+    }
+}

--- a/src/RecruitAI.Contratos/Validaciones/Candidatos/EditarCandidatoValidador.cs
+++ b/src/RecruitAI.Contratos/Validaciones/Candidatos/EditarCandidatoValidador.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+using RecruitAI.Contratos.Dtos.Candidatos;
+
+namespace RecruitAI.Contratos.Validaciones.Candidatos;
+
+public class EditarCandidatoValidador : AbstractValidator<EditarCandidatoDto>
+{
+    public EditarCandidatoValidador()
+    {
+        RuleFor(x => x.NombreCompleto)
+            .NotEmpty().WithMessage("El nombre completo es obligatorio.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("El correo es obligatorio.")
+            .EmailAddress().WithMessage("El correo debe tener un formato válido.");
+
+        RuleFor(x => x.CvTexto)
+            .NotEmpty().WithMessage("El CV no puede estar vacío.");
+    }
+}

--- a/src/RecruitAI.Contratos/Validaciones/Puestos/CrearPuestoValidador.cs
+++ b/src/RecruitAI.Contratos/Validaciones/Puestos/CrearPuestoValidador.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using RecruitAI.Contratos.Dtos.Puestos;
+
+namespace RecruitAI.Contratos.Validaciones.Puestos;
+
+public class CrearPuestoValidador : AbstractValidator<CrearPuestoDto>
+{
+    public CrearPuestoValidador()
+    {
+        RuleFor(x => x.Titulo)
+            .NotEmpty().WithMessage("El título es obligatorio.")
+            .MaximumLength(120).WithMessage("El título no puede superar 120 caracteres.");
+
+        RuleFor(x => x.Descripcion)
+            .NotEmpty().WithMessage("La descripción es obligatoria.")
+            .MinimumLength(30).WithMessage("La descripción debe tener al menos 30 caracteres.");
+
+        RuleForEach(x => x.HabilidadesRequeridas)
+            .MaximumLength(60).WithMessage("Cada habilidad no puede superar 60 caracteres.");
+    }
+}

--- a/src/RecruitAI.Contratos/Validaciones/Puestos/EditarPuestoValidador.cs
+++ b/src/RecruitAI.Contratos/Validaciones/Puestos/EditarPuestoValidador.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+using RecruitAI.Contratos.Dtos.Puestos;
+
+namespace RecruitAI.Contratos.Validaciones.Puestos;
+
+public class EditarPuestoValidador : AbstractValidator<EditarPuestoDto>
+{
+    public EditarPuestoValidador()
+    {
+        RuleFor(x => x.Titulo)
+            .NotEmpty().WithMessage("El título es obligatorio.")
+            .MaximumLength(120).WithMessage("El título no puede superar 120 caracteres.");
+
+        RuleFor(x => x.Descripcion)
+            .NotEmpty().WithMessage("La descripción es obligatoria.")
+            .MinimumLength(30).WithMessage("La descripción debe tener al menos 30 caracteres.");
+
+        RuleForEach(x => x.HabilidadesRequeridas)
+            .MaximumLength(60).WithMessage("Cada habilidad no puede superar 60 caracteres.");
+    }
+}

--- a/src/RecruitAI.Datos/Entidades/Candidato.cs
+++ b/src/RecruitAI.Datos/Entidades/Candidato.cs
@@ -1,0 +1,16 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Datos.Entidades;
+
+public class Candidato : ICandidatoEntidad
+{
+    public Guid Id { get; set; }
+    public string NombreCompleto { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string? Fuente { get; set; }
+    public string CvTexto { get; set; } = string.Empty;
+    public DateTime CreadoEl { get; set; } = DateTime.UtcNow;
+    public string? Embedding { get; set; }
+
+    public EmbeddingCandidato? EmbeddingCandidato { get; set; }
+}

--- a/src/RecruitAI.Datos/Entidades/EmbeddingCandidato.cs
+++ b/src/RecruitAI.Datos/Entidades/EmbeddingCandidato.cs
@@ -1,0 +1,13 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Datos.Entidades;
+
+public class EmbeddingCandidato : IEmbeddingEntidad
+{
+    public Guid CandidatoId { get; set; }
+    public byte[]? Vector { get; set; }
+    public string Modelo { get; set; } = "text-embedding-3-large";
+    public DateTime ActualizadoEl { get; set; } = DateTime.UtcNow;
+
+    public Candidato Candidato { get; set; } = null!;
+}

--- a/src/RecruitAI.Datos/Entidades/EmbeddingPuesto.cs
+++ b/src/RecruitAI.Datos/Entidades/EmbeddingPuesto.cs
@@ -1,0 +1,13 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Datos.Entidades;
+
+public class EmbeddingPuesto : IEmbeddingEntidad
+{
+    public Guid PuestoId { get; set; }
+    public byte[]? Vector { get; set; }
+    public string Modelo { get; set; } = "text-embedding-3-large";
+    public DateTime ActualizadoEl { get; set; } = DateTime.UtcNow;
+
+    public Puesto Puesto { get; set; } = null!;
+}

--- a/src/RecruitAI.Datos/Entidades/Puesto.cs
+++ b/src/RecruitAI.Datos/Entidades/Puesto.cs
@@ -1,0 +1,17 @@
+using RecruitAI.Contratos.Entidades;
+
+namespace RecruitAI.Datos.Entidades;
+
+public class Puesto : IPuestoEntidad
+{
+    public Guid Id { get; set; }
+    public string Titulo { get; set; } = string.Empty;
+    public string Descripcion { get; set; } = string.Empty;
+    public string? Seniority { get; set; }
+    public string? Ubicacion { get; set; }
+    public string? HabilidadesRequeridasJson { get; set; }
+    public DateTime CreadoEl { get; set; } = DateTime.UtcNow;
+    public string? Embedding { get; set; }
+
+    public EmbeddingPuesto? EmbeddingPuesto { get; set; }
+}

--- a/src/RecruitAI.Datos/Persistencia/CherokeeDbContext.cs
+++ b/src/RecruitAI.Datos/Persistencia/CherokeeDbContext.cs
@@ -1,0 +1,70 @@
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Datos.Entidades;
+
+namespace RecruitAI.Datos.Persistencia;
+
+public class CherokeeDbContext : DbContext
+{
+    public CherokeeDbContext(DbContextOptions<CherokeeDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Puesto> Puestos => Set<Puesto>();
+    public DbSet<Candidato> Candidatos => Set<Candidato>();
+    public DbSet<EmbeddingPuesto> EmbeddingsPuestos => Set<EmbeddingPuesto>();
+    public DbSet<EmbeddingCandidato> EmbeddingsCandidatos => Set<EmbeddingCandidato>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<Puesto>(entity =>
+        {
+            entity.ToTable("Puestos");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Titulo).HasMaxLength(200);
+            entity.Property(e => e.Seniority).HasMaxLength(100);
+            entity.Property(e => e.Ubicacion).HasMaxLength(150);
+            entity.Property(e => e.HabilidadesRequeridasJson).HasColumnType("nvarchar(max)");
+            entity.Property(e => e.Embedding).HasColumnType("nvarchar(max)");
+            entity.Property(e => e.CreadoEl).HasDefaultValueSql("GETUTCDATE()");
+
+            entity.HasOne(e => e.EmbeddingPuesto)
+                .WithOne(e => e.Puesto)
+                .HasForeignKey<EmbeddingPuesto>(e => e.PuestoId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Candidato>(entity =>
+        {
+            entity.ToTable("Candidatos");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.NombreCompleto).HasMaxLength(200);
+            entity.Property(e => e.Email).HasMaxLength(200);
+            entity.Property(e => e.Fuente).HasMaxLength(150);
+            entity.Property(e => e.Embedding).HasColumnType("nvarchar(max)");
+            entity.Property(e => e.CreadoEl).HasDefaultValueSql("GETUTCDATE()");
+
+            entity.HasOne(e => e.EmbeddingCandidato)
+                .WithOne(e => e.Candidato)
+                .HasForeignKey<EmbeddingCandidato>(e => e.CandidatoId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<EmbeddingPuesto>(entity =>
+        {
+            entity.ToTable("EmbeddingsPuestos");
+            entity.HasKey(e => e.PuestoId);
+            entity.Property(e => e.Vector).HasColumnType("varbinary(max)");
+            entity.Property(e => e.Modelo).HasMaxLength(200);
+        });
+
+        modelBuilder.Entity<EmbeddingCandidato>(entity =>
+        {
+            entity.ToTable("EmbeddingsCandidatos");
+            entity.HasKey(e => e.CandidatoId);
+            entity.Property(e => e.Vector).HasColumnType("varbinary(max)");
+            entity.Property(e => e.Modelo).HasMaxLength(200);
+        });
+    }
+}

--- a/src/RecruitAI.Datos/Persistencia/CherokeeDbContextLectura.cs
+++ b/src/RecruitAI.Datos/Persistencia/CherokeeDbContextLectura.cs
@@ -1,0 +1,11 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace RecruitAI.Datos.Persistencia;
+
+public class CherokeeDbContextLectura : CherokeeDbContext
+{
+    public CherokeeDbContextLectura(DbContextOptions<CherokeeDbContextLectura> options)
+        : base(options)
+    {
+    }
+}

--- a/src/RecruitAI.Datos/RecruitAI.Datos.csproj
+++ b/src/RecruitAI.Datos/RecruitAI.Datos.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../RecruitAI.Contratos/RecruitAI.Contratos.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/src/RecruitAI.Datos/Repositorios/CandidatoRepositorio.cs
+++ b/src/RecruitAI.Datos/Repositorios/CandidatoRepositorio.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Entidades;
+using RecruitAI.Contratos.Interfaces.Repositorios;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Datos.Repositorios;
+
+public class CandidatoRepositorio : RepositorioGenerico<Candidato, ICandidatoEntidad>, ICandidatoRepositorio
+{
+    public CandidatoRepositorio(CherokeeDbContext context) : base(context)
+    {
+    }
+
+    public async Task<ICandidatoEntidad?> ObtenerConEmbeddingAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entidad = await Context.Candidatos
+            .Include(x => x.EmbeddingCandidato)
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return entidad;
+    }
+
+    public async Task<List<ICandidatoEntidad>> ListarConEmbeddingAsync(CancellationToken cancellationToken = default)
+    {
+        var entidades = await Context.Candidatos
+            .Include(x => x.EmbeddingCandidato)
+            .ToListAsync(cancellationToken);
+        return entidades.Cast<ICandidatoEntidad>().ToList();
+    }
+}

--- a/src/RecruitAI.Datos/Repositorios/PuestoRepositorio.cs
+++ b/src/RecruitAI.Datos/Repositorios/PuestoRepositorio.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Entidades;
+using RecruitAI.Contratos.Interfaces.Repositorios;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Datos.Repositorios;
+
+public class PuestoRepositorio : RepositorioGenerico<Puesto, IPuestoEntidad>, IPuestoRepositorio
+{
+    public PuestoRepositorio(CherokeeDbContext context) : base(context)
+    {
+    }
+
+    public async Task<IPuestoEntidad?> ObtenerConEmbeddingAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entidad = await Context.Puestos
+            .Include(x => x.EmbeddingPuesto)
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        return entidad;
+    }
+}

--- a/src/RecruitAI.Datos/Repositorios/RepositorioGenerico.cs
+++ b/src/RecruitAI.Datos/Repositorios/RepositorioGenerico.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Interfaces.Repositorios;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Datos.Repositorios;
+
+public class RepositorioGenerico<TEntity, TModelo> : IRepositorioGenerico<TModelo>
+    where TEntity : class, TModelo
+{
+    protected readonly CherokeeDbContext Context;
+    protected readonly DbSet<TEntity> Conjunto;
+
+    public RepositorioGenerico(CherokeeDbContext context)
+    {
+        Context = context;
+        Conjunto = context.Set<TEntity>();
+    }
+
+    public virtual async Task<TModelo?> ObtenerPorIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entidad = await Conjunto.FindAsync(new object?[] { id }, cancellationToken);
+        return entidad;
+    }
+
+    public virtual async Task<List<TModelo>> ListarAsync(CancellationToken cancellationToken = default)
+    {
+        var resultados = await Conjunto.ToListAsync(cancellationToken);
+        return resultados.Cast<TModelo>().ToList();
+    }
+
+    public virtual async Task AgregarAsync(TModelo entidad, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entidad);
+        await Conjunto.AddAsync((TEntity)entidad, cancellationToken);
+    }
+
+    public virtual Task ActualizarAsync(TModelo entidad, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entidad);
+        Conjunto.Update((TEntity)entidad);
+        return Task.CompletedTask;
+    }
+
+    public virtual Task EliminarAsync(TModelo entidad, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entidad);
+        Conjunto.Remove((TEntity)entidad);
+        return Task.CompletedTask;
+    }
+
+    public virtual Task GuardarCambiosAsync(CancellationToken cancellationToken = default)
+    {
+        return Context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/RecruitAI.Servicios/Implementaciones/CoincidenciasServicio.cs
+++ b/src/RecruitAI.Servicios/Implementaciones/CoincidenciasServicio.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using RecruitAI.Contratos.Dtos.Coincidencias;
+using RecruitAI.Contratos.Interfaces.Repositorios;
+using RecruitAI.Contratos.Interfaces.Servicios;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Servicios.Utilidades;
+
+namespace RecruitAI.Servicios.Implementaciones;
+
+public class CoincidenciasServicio : ICoincidenciasServicio
+{
+    private readonly IPuestoRepositorio _puestoRepositorio;
+    private readonly ICandidatoRepositorio _candidatoRepositorio;
+    private readonly IEmbeddingsServicio _embeddingsServicio;
+
+    public CoincidenciasServicio(
+        IPuestoRepositorio puestoRepositorio,
+        ICandidatoRepositorio candidatoRepositorio,
+        IEmbeddingsServicio embeddingsServicio)
+    {
+        _puestoRepositorio = puestoRepositorio;
+        _candidatoRepositorio = candidatoRepositorio;
+        _embeddingsServicio = embeddingsServicio;
+    }
+
+    public async Task<IReadOnlyCollection<CoincidenciaDto>> TopPorPuestoAsync(Guid puestoId, int cantidad = 20, double? umbral = null, CancellationToken cancellationToken = default)
+    {
+        var puesto = await _puestoRepositorio.ObtenerConEmbeddingAsync(puestoId, cancellationToken)
+            ?? throw new InvalidOperationException("No se encontró el puesto solicitado.");
+
+        if (puesto is not Puesto puestoEntidad || puestoEntidad.EmbeddingPuesto?.Vector is null)
+        {
+            throw new InvalidOperationException("El puesto no tiene un embedding generado. Genera el vector antes de calcular coincidencias.");
+        }
+
+        var vectorPuesto = _embeddingsServicio.ConvertirAFlotantes(puestoEntidad.EmbeddingPuesto.Vector);
+
+        var candidatos = await _candidatoRepositorio.ListarConEmbeddingAsync(cancellationToken);
+
+        var coincidencias = new List<CoincidenciaDto>();
+        foreach (var candidato in candidatos)
+        {
+            if (candidato is not Candidato candidatoEntidad)
+            {
+                continue;
+            }
+
+            var vectorBytes = candidatoEntidad.EmbeddingCandidato?.Vector;
+            if (vectorBytes is null)
+            {
+                continue;
+            }
+
+            var vectorCandidato = _embeddingsServicio.ConvertirAFlotantes(vectorBytes);
+            var similitud = VectorUtil.CalcularCoseno(vectorPuesto, vectorCandidato);
+            var puntaje = Math.Round(similitud * 100, 2, MidpointRounding.AwayFromZero);
+
+            if (umbral.HasValue && similitud < umbral.Value)
+            {
+                continue;
+            }
+
+            coincidencias.Add(new CoincidenciaDto
+            {
+                CandidatoId = candidatoEntidad.Id,
+                NombreCompleto = candidatoEntidad.NombreCompleto,
+                Email = candidatoEntidad.Email,
+                Puntaje = puntaje
+            });
+        }
+
+        return coincidencias
+            .OrderByDescending(x => x.Puntaje)
+            .Take(cantidad)
+            .ToList();
+    }
+}

--- a/src/RecruitAI.Servicios/Implementaciones/EmbeddingsServicio.cs
+++ b/src/RecruitAI.Servicios/Implementaciones/EmbeddingsServicio.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Configuration;
+using RecruitAI.Contratos.Interfaces.Servicios;
+using RecruitAI.Servicios.Utilidades;
+
+namespace RecruitAI.Servicios.Implementaciones;
+
+public class EmbeddingsServicio : IEmbeddingsServicio
+{
+    private readonly HttpClient _httpClient;
+    private readonly IConfiguration _configuration;
+
+    public EmbeddingsServicio(HttpClient httpClient, IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _configuration = configuration;
+    }
+
+    public async Task<float[]> GenerarEmbeddingAsync(string texto, string modelo = "text-embedding-3-large", CancellationToken cancellationToken = default)
+    {
+        var apiKey = _configuration["OpenAI:ApiKey"];
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new InvalidOperationException("No se configuró la clave de OpenAI. Actualiza appsettings.json o las variables de entorno.");
+        }
+
+        _httpClient.BaseAddress ??= new Uri("https://api.openai.com/");
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var request = new
+        {
+            model = modelo,
+            input = texto
+        };
+
+        using var respuesta = await _httpClient.PostAsJsonAsync("v1/embeddings", request, cancellationToken);
+        respuesta.EnsureSuccessStatusCode();
+
+        var contenido = await respuesta.Content.ReadFromJsonAsync<EmbeddingRespuesta>(cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("No se pudo deserializar la respuesta de OpenAI.");
+
+        var vector = contenido.data.FirstOrDefault()?.embedding
+            ?? throw new InvalidOperationException("OpenAI no devolvió ningún vector de embedding.");
+
+        return vector;
+    }
+
+    public byte[] ConvertirABytes(float[] vector) => VectorUtil.ConvertirABytes(vector);
+
+    public float[] ConvertirAFlotantes(byte[] datos) => VectorUtil.ConvertirAFlotantes(datos);
+
+    private sealed record EmbeddingRespuesta(List<EmbeddingDato> data);
+
+    private sealed record EmbeddingDato(List<float> embedding);
+}

--- a/src/RecruitAI.Servicios/Implementaciones/IaServicio.cs
+++ b/src/RecruitAI.Servicios/Implementaciones/IaServicio.cs
@@ -1,0 +1,17 @@
+using RecruitAI.Contratos.Dtos.Ia;
+using RecruitAI.Contratos.Interfaces.Servicios;
+
+namespace RecruitAI.Servicios.Implementaciones;
+
+public class IaServicio : IIaServicio
+{
+    public Task<string> ExtraerCvAsync(ExtraerCvRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult("Funcionalidad de extracción pendiente de implementar.");
+    }
+
+    public Task<double> PuntuarAsync(PuntuarRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(0d);
+    }
+}

--- a/src/RecruitAI.Servicios/RecruitAI.Servicios.csproj
+++ b/src/RecruitAI.Servicios/RecruitAI.Servicios.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../RecruitAI.Contratos/RecruitAI.Contratos.csproj" />
+    <ProjectReference Include="../RecruitAI.Datos/RecruitAI.Datos.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/RecruitAI.Servicios/Utilidades/VectorUtil.cs
+++ b/src/RecruitAI.Servicios/Utilidades/VectorUtil.cs
@@ -1,0 +1,60 @@
+using System.Runtime.InteropServices;
+
+namespace RecruitAI.Servicios.Utilidades;
+
+public static class VectorUtil
+{
+    public static double CalcularCoseno(IReadOnlyList<float> vectorA, IReadOnlyList<float> vectorB)
+    {
+        if (vectorA.Count == 0 || vectorB.Count == 0)
+        {
+            return 0d;
+        }
+
+        if (vectorA.Count != vectorB.Count)
+        {
+            throw new ArgumentException("Los vectores deben tener la misma longitud.");
+        }
+
+        double producto = 0d;
+        double normaA = 0d;
+        double normaB = 0d;
+
+        for (var i = 0; i < vectorA.Count; i++)
+        {
+            var a = vectorA[i];
+            var b = vectorB[i];
+            producto += a * b;
+            normaA += a * a;
+            normaB += b * b;
+        }
+
+        if (normaA == 0 || normaB == 0)
+        {
+            return 0d;
+        }
+
+        return producto / (Math.Sqrt(normaA) * Math.Sqrt(normaB));
+    }
+
+    public static byte[] ConvertirABytes(float[] valores)
+    {
+        var resultado = new byte[valores.Length * sizeof(float)];
+        var destino = MemoryMarshal.Cast<byte, float>(resultado.AsSpan());
+        valores.AsSpan().CopyTo(destino);
+        return resultado;
+    }
+
+    public static float[] ConvertirAFlotantes(byte[] datos)
+    {
+        if (datos.Length % sizeof(float) != 0)
+        {
+            throw new ArgumentException("El arreglo de bytes no representa una secuencia válida de flotantes.");
+        }
+
+        var resultado = new float[datos.Length / sizeof(float)];
+        var origen = MemoryMarshal.Cast<byte, float>(datos.AsSpan());
+        origen.CopyTo(resultado);
+        return resultado;
+    }
+}

--- a/src/RecruitAI.Web/Controllers/CandidatosController.cs
+++ b/src/RecruitAI.Web/Controllers/CandidatosController.cs
@@ -1,0 +1,115 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Dtos.Candidatos;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CandidatosController : ControllerBase
+{
+    private readonly CherokeeDbContext _contexto;
+    private readonly CherokeeDbContextLectura _contextoLectura;
+
+    public CandidatosController(CherokeeDbContext contexto, CherokeeDbContextLectura contextoLectura)
+    {
+        _contexto = contexto;
+        _contextoLectura = contextoLectura;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<CandidatoDto>>> ObtenerAsync(CancellationToken cancellationToken)
+    {
+        var candidatos = await _contextoLectura.Candidatos
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        var resultado = candidatos.Select(MapearCandidato).ToList();
+        return Ok(resultado);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<CandidatoDto>> ObtenerPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var candidato = await _contextoLectura.Candidatos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+
+        if (candidato is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(MapearCandidato(candidato));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<CandidatoDto>> CrearAsync([FromBody] CrearCandidatoDto dto, CancellationToken cancellationToken)
+    {
+        var candidato = new Candidato
+        {
+            Id = Guid.NewGuid(),
+            NombreCompleto = dto.NombreCompleto,
+            Email = dto.Email,
+            Fuente = dto.Fuente,
+            CvTexto = dto.CvTexto,
+            CreadoEl = DateTime.UtcNow
+        };
+
+        await _contexto.Candidatos.AddAsync(candidato, cancellationToken);
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        var resultado = MapearCandidato(candidato);
+        return CreatedAtAction(nameof(ObtenerPorIdAsync), new { id = candidato.Id }, resultado);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<CandidatoDto>> ActualizarAsync(Guid id, [FromBody] EditarCandidatoDto dto, CancellationToken cancellationToken)
+    {
+        var candidato = await _contexto.Candidatos.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (candidato is null)
+        {
+            return NotFound();
+        }
+
+        candidato.NombreCompleto = dto.NombreCompleto;
+        candidato.Email = dto.Email;
+        candidato.Fuente = dto.Fuente;
+        candidato.CvTexto = dto.CvTexto;
+
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return Ok(MapearCandidato(candidato));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> EliminarAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var candidato = await _contexto.Candidatos.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (candidato is null)
+        {
+            return NotFound();
+        }
+
+        _contexto.Candidatos.Remove(candidato);
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    private static CandidatoDto MapearCandidato(Candidato candidato)
+    {
+        return new CandidatoDto
+        {
+            Id = candidato.Id,
+            NombreCompleto = candidato.NombreCompleto,
+            Email = candidato.Email,
+            Fuente = candidato.Fuente,
+            CvTexto = candidato.CvTexto,
+            CreadoEl = candidato.CreadoEl
+        };
+    }
+}

--- a/src/RecruitAI.Web/Controllers/CoincidenciasController.cs
+++ b/src/RecruitAI.Web/Controllers/CoincidenciasController.cs
@@ -1,0 +1,126 @@
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Dtos.Coincidencias;
+using RecruitAI.Contratos.Interfaces.Servicios;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CoincidenciasController : ControllerBase
+{
+    private readonly CherokeeDbContext _contexto;
+    private readonly IEmbeddingsServicio _embeddingsServicio;
+    private readonly ICoincidenciasServicio _coincidenciasServicio;
+
+    public CoincidenciasController(
+        CherokeeDbContext contexto,
+        IEmbeddingsServicio embeddingsServicio,
+        ICoincidenciasServicio coincidenciasServicio)
+    {
+        _contexto = contexto;
+        _embeddingsServicio = embeddingsServicio;
+        _coincidenciasServicio = coincidenciasServicio;
+    }
+
+    [HttpPost("puestos/{puestoId:guid}/embedding")]
+    public async Task<IActionResult> GenerarEmbeddingPuestoAsync(Guid puestoId, CancellationToken cancellationToken)
+    {
+        var puesto = await _contexto.Puestos
+            .Include(x => x.EmbeddingPuesto)
+            .FirstOrDefaultAsync(x => x.Id == puestoId, cancellationToken);
+
+        if (puesto is null)
+        {
+            return NotFound();
+        }
+
+        var habilidades = puesto.HabilidadesRequeridasJson is null
+            ? Array.Empty<string>()
+            : JsonSerializer.Deserialize<string[]>(puesto.HabilidadesRequeridasJson) ?? Array.Empty<string>();
+
+        var texto = string.Join(" \n", new[]
+        {
+            puesto.Titulo,
+            puesto.Descripcion,
+            puesto.Seniority ?? string.Empty,
+            puesto.Ubicacion ?? string.Empty,
+            string.Join(", ", habilidades)
+        }.Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        var vector = await _embeddingsServicio.GenerarEmbeddingAsync(texto, cancellationToken: cancellationToken);
+        var bytes = _embeddingsServicio.ConvertirABytes(vector);
+
+        if (puesto.EmbeddingPuesto is null)
+        {
+            puesto.EmbeddingPuesto = new EmbeddingPuesto
+            {
+                PuestoId = puesto.Id,
+                Vector = bytes,
+                ActualizadoEl = DateTime.UtcNow
+            };
+        }
+        else
+        {
+            puesto.EmbeddingPuesto.Vector = bytes;
+            puesto.EmbeddingPuesto.ActualizadoEl = DateTime.UtcNow;
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return Ok(new { puestoId, longitud = vector.Length });
+    }
+
+    [HttpPost("candidatos/{candidatoId:guid}/embedding")]
+    public async Task<IActionResult> GenerarEmbeddingCandidatoAsync(Guid candidatoId, CancellationToken cancellationToken)
+    {
+        var candidato = await _contexto.Candidatos
+            .Include(x => x.EmbeddingCandidato)
+            .FirstOrDefaultAsync(x => x.Id == candidatoId, cancellationToken);
+
+        if (candidato is null)
+        {
+            return NotFound();
+        }
+
+        var vector = await _embeddingsServicio.GenerarEmbeddingAsync(candidato.CvTexto, cancellationToken: cancellationToken);
+        var bytes = _embeddingsServicio.ConvertirABytes(vector);
+
+        if (candidato.EmbeddingCandidato is null)
+        {
+            candidato.EmbeddingCandidato = new EmbeddingCandidato
+            {
+                CandidatoId = candidato.Id,
+                Vector = bytes,
+                ActualizadoEl = DateTime.UtcNow
+            };
+        }
+        else
+        {
+            candidato.EmbeddingCandidato.Vector = bytes;
+            candidato.EmbeddingCandidato.ActualizadoEl = DateTime.UtcNow;
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return Ok(new { candidatoId, longitud = vector.Length });
+    }
+
+    [HttpGet("puestos/{puestoId:guid}/top")]
+    public async Task<ActionResult<IEnumerable<CoincidenciaDto>>> ObtenerTopAsync(Guid puestoId, [FromQuery] TopCoincidenciasRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var resultado = await _coincidenciasServicio.TopPorPuestoAsync(puestoId, request.Cantidad, request.Umbral, cancellationToken);
+            return Ok(resultado);
+        }
+        catch (InvalidOperationException excepcion)
+        {
+            return BadRequest(new { mensaje = excepcion.Message });
+        }
+    }
+}

--- a/src/RecruitAI.Web/Controllers/IaController.cs
+++ b/src/RecruitAI.Web/Controllers/IaController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using RecruitAI.Contratos.Dtos.Ia;
+using RecruitAI.Contratos.Interfaces.Servicios;
+
+namespace RecruitAI.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class IaController : ControllerBase
+{
+    private readonly IIaServicio _iaServicio;
+
+    public IaController(IIaServicio iaServicio)
+    {
+        _iaServicio = iaServicio;
+    }
+
+    [HttpPost("extraer-cv")]
+    public async Task<ActionResult<string>> ExtraerCvAsync([FromBody] ExtraerCvRequest request, CancellationToken cancellationToken)
+    {
+        var resultado = await _iaServicio.ExtraerCvAsync(request, cancellationToken);
+        return Ok(resultado);
+    }
+
+    [HttpPost("puntuar")]
+    public async Task<ActionResult<double>> PuntuarAsync([FromBody] PuntuarRequest request, CancellationToken cancellationToken)
+    {
+        var resultado = await _iaServicio.PuntuarAsync(request, cancellationToken);
+        return Ok(resultado);
+    }
+}

--- a/src/RecruitAI.Web/Controllers/PuestosController.cs
+++ b/src/RecruitAI.Web/Controllers/PuestosController.cs
@@ -1,0 +1,127 @@
+using System.Linq;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using RecruitAI.Contratos.Dtos.Puestos;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+
+namespace RecruitAI.Web.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PuestosController : ControllerBase
+{
+    private readonly CherokeeDbContext _contexto;
+    private readonly CherokeeDbContextLectura _contextoLectura;
+
+    public PuestosController(CherokeeDbContext contexto, CherokeeDbContextLectura contextoLectura)
+    {
+        _contexto = contexto;
+        _contextoLectura = contextoLectura;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<PuestoDto>>> ObtenerAsync(CancellationToken cancellationToken)
+    {
+        var puestos = await _contextoLectura.Puestos
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        var resultado = puestos.Select(MapearPuesto).ToList();
+        return Ok(resultado);
+    }
+
+    [HttpGet("{id:guid}")]
+    public async Task<ActionResult<PuestoDto>> ObtenerPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var puesto = await _contextoLectura.Puestos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+
+        if (puesto is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(MapearPuesto(puesto));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<PuestoDto>> CrearAsync([FromBody] CrearPuestoDto dto, CancellationToken cancellationToken)
+    {
+        var puesto = new Puesto
+        {
+            Id = Guid.NewGuid(),
+            Titulo = dto.Titulo,
+            Descripcion = dto.Descripcion,
+            Seniority = dto.Seniority,
+            Ubicacion = dto.Ubicacion,
+            HabilidadesRequeridasJson = dto.HabilidadesRequeridas.Any()
+                ? JsonSerializer.Serialize(dto.HabilidadesRequeridas)
+                : null,
+            CreadoEl = DateTime.UtcNow
+        };
+
+        await _contexto.Puestos.AddAsync(puesto, cancellationToken);
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        var resultado = MapearPuesto(puesto);
+        return CreatedAtAction(nameof(ObtenerPorIdAsync), new { id = puesto.Id }, resultado);
+    }
+
+    [HttpPut("{id:guid}")]
+    public async Task<ActionResult<PuestoDto>> ActualizarAsync(Guid id, [FromBody] EditarPuestoDto dto, CancellationToken cancellationToken)
+    {
+        var puesto = await _contexto.Puestos.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (puesto is null)
+        {
+            return NotFound();
+        }
+
+        puesto.Titulo = dto.Titulo;
+        puesto.Descripcion = dto.Descripcion;
+        puesto.Seniority = dto.Seniority;
+        puesto.Ubicacion = dto.Ubicacion;
+        puesto.HabilidadesRequeridasJson = dto.HabilidadesRequeridas.Any()
+            ? JsonSerializer.Serialize(dto.HabilidadesRequeridas)
+            : null;
+
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return Ok(MapearPuesto(puesto));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> EliminarAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var puesto = await _contexto.Puestos.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        if (puesto is null)
+        {
+            return NotFound();
+        }
+
+        _contexto.Puestos.Remove(puesto);
+        await _contexto.SaveChangesAsync(cancellationToken);
+
+        return NoContent();
+    }
+
+    private static PuestoDto MapearPuesto(Puesto puesto)
+    {
+        var habilidades = puesto.HabilidadesRequeridasJson is null
+            ? Array.Empty<string>()
+            : JsonSerializer.Deserialize<string[]>(puesto.HabilidadesRequeridasJson) ?? Array.Empty<string>();
+
+        return new PuestoDto
+        {
+            Id = puesto.Id,
+            Titulo = puesto.Titulo,
+            Descripcion = puesto.Descripcion,
+            Seniority = puesto.Seniority,
+            Ubicacion = puesto.Ubicacion,
+            HabilidadesRequeridas = habilidades,
+            CreadoEl = puesto.CreadoEl
+        };
+    }
+}

--- a/src/RecruitAI.Web/Program.cs
+++ b/src/RecruitAI.Web/Program.cs
@@ -1,0 +1,152 @@
+using System.Text.Json;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using RecruitAI.Contratos.Interfaces.Repositorios;
+using RecruitAI.Contratos.Interfaces.Servicios;
+using RecruitAI.Datos.Entidades;
+using RecruitAI.Datos.Persistencia;
+using RecruitAI.Datos.Repositorios;
+using RecruitAI.Servicios.Implementaciones;
+using Serilog;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((contexto, servicios, configuracion) =>
+    configuracion.ReadFrom.Configuration(contexto.Configuration).ReadFrom.Services(servicios));
+
+builder.Services.AddControllers();
+
+builder.Services.AddFluentValidationAutoValidation();
+builder.Services.AddValidatorsFromAssemblies(AppDomain.CurrentDomain.GetAssemblies());
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(opciones =>
+{
+    opciones.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "RecruitAI API",
+        Version = "v1",
+        Description = "API de reclutamiento asistido por IA"
+    });
+
+    var esquema = new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Introduce un token JWT válido"
+    };
+
+    opciones.AddSecurityDefinition("Bearer", esquema);
+    opciones.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            esquema,
+            Array.Empty<string>()
+        }
+    });
+});
+
+builder.Services.AddCors(opciones =>
+{
+    opciones.AddPolicy("cors-desarrollo", configuracion =>
+    {
+        configuracion
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowAnyOrigin();
+    });
+});
+
+var cadenaCompleta = builder.Configuration.GetConnectionString("RecruitAIConexionCompleta")
+    ?? throw new InvalidOperationException("No se encontró la cadena de conexión 'RecruitAIConexionCompleta'.");
+var cadenaLectura = builder.Configuration.GetConnectionString("RecruitAIConexionSoloLectura")
+    ?? throw new InvalidOperationException("No se encontró la cadena de conexión 'RecruitAIConexionSoloLectura'.");
+
+builder.Services.AddDbContext<CherokeeDbContext>(opciones =>
+{
+    opciones.UseSqlServer(cadenaCompleta);
+});
+
+builder.Services.AddDbContext<CherokeeDbContextLectura>(opciones =>
+{
+    opciones.UseSqlServer(cadenaLectura);
+});
+
+builder.Services.AddScoped<IPuestoRepositorio, PuestoRepositorio>();
+builder.Services.AddScoped<ICandidatoRepositorio, CandidatoRepositorio>();
+builder.Services.AddScoped<ICoincidenciasServicio, CoincidenciasServicio>();
+builder.Services.AddScoped<IIaServicio, IaServicio>();
+builder.Services.AddHttpClient<IEmbeddingsServicio, EmbeddingsServicio>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseSerilogRequestLogging();
+
+app.UseCors("cors-desarrollo");
+
+app.UseHttpsRedirection();
+
+// app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+await InicializarDatosAsync(app.Services);
+
+app.Run();
+
+static async Task InicializarDatosAsync(IServiceProvider servicios)
+{
+    using var alcance = servicios.CreateScope();
+    var contexto = alcance.ServiceProvider.GetRequiredService<CherokeeDbContext>();
+
+    await contexto.Database.EnsureCreatedAsync();
+
+    if (!await contexto.Puestos.AnyAsync())
+    {
+        var puestoDemo = new Puesto
+        {
+            Id = Guid.NewGuid(),
+            Titulo = "Desarrollador .NET",
+            Descripcion = "Buscamos un desarrollador .NET con pasión por crear APIs escalables y mantenibles.",
+            Seniority = "Semi Senior",
+            Ubicacion = "Remoto",
+            HabilidadesRequeridasJson = JsonSerializer.Serialize(new[] { ".NET", "SQL", "Azure" })
+        };
+
+        contexto.Puestos.Add(puestoDemo);
+
+        var candidato1 = new Candidato
+        {
+            Id = Guid.NewGuid(),
+            NombreCompleto = "María González",
+            Email = "maria@example.com",
+            Fuente = "LinkedIn",
+            CvTexto = "Desarrolladora con experiencia en .NET, Azure y SQL Server.",
+        };
+
+        var candidato2 = new Candidato
+        {
+            Id = Guid.NewGuid(),
+            NombreCompleto = "Carlos Pérez",
+            Email = "carlos@example.com",
+            Fuente = "Recomendación",
+            CvTexto = "Ingeniero de software con foco en microservicios y bases de datos relacionales.",
+        };
+
+        contexto.Candidatos.AddRange(candidato1, candidato2);
+
+        await contexto.SaveChangesAsync();
+    }
+}

--- a/src/RecruitAI.Web/RecruitAI.Web.csproj
+++ b/src/RecruitAI.Web/RecruitAI.Web.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../RecruitAI.Contratos/RecruitAI.Contratos.csproj" />
+    <ProjectReference Include="../RecruitAI.Datos/RecruitAI.Datos.csproj" />
+    <ProjectReference Include="../RecruitAI.Servicios/RecruitAI.Servicios.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
+  </ItemGroup>
+</Project>

--- a/src/RecruitAI.Web/appsettings.json
+++ b/src/RecruitAI.Web/appsettings.json
@@ -1,0 +1,20 @@
+{
+  "ConnectionStrings": {
+    "RecruitAIConexionCompleta": "Server=DESKTOP-8L1PQ7F;Database=RecruitAI;Trusted_Connection=True;TrustServerCertificate=True;",
+    "RecruitAIConexionSoloLectura": "Server=DESKTOP-8L1PQ7F;Database=RecruitAI;Trusted_Connection=True;TrustServerCertificate=True;"
+  },
+  "OpenAI": {
+    "ApiKey": "sk-xxxx"
+  },
+  "Jwt": {
+    "Emisor": "http://localhost",
+    "Audiencia": "http://localhost",
+    "Secreto": "cambialo-porfavor"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tests/RecruitAI.Tests/RecruitAI.Tests.csproj
+++ b/tests/RecruitAI.Tests/RecruitAI.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/RecruitAI.Servicios/RecruitAI.Servicios.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/RecruitAI.Tests/VectorUtilTests.cs
+++ b/tests/RecruitAI.Tests/VectorUtilTests.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+using RecruitAI.Servicios.Utilidades;
+using Xunit;
+
+namespace RecruitAI.Tests;
+
+public class VectorUtilTests
+{
+    [Fact]
+    public void CalcularCoseno_DeberiaRetornarUnoParaVectoresIguales()
+    {
+        var vector = new[] { 1f, 2f, 3f };
+
+        var resultado = VectorUtil.CalcularCoseno(vector, vector);
+
+        resultado.Should().BeApproximately(1d, 1e-6);
+    }
+}


### PR DESCRIPTION
## Resumen
- renombra las cadenas de conexión para que utilicen el prefijo RecruitAI
- apunta la base de datos de configuración y documentación a RecruitAI

## Pruebas
- no se ejecutaron (entorno sin SDK .NET)


------
https://chatgpt.com/codex/tasks/task_e_68e424ef9bc08332b0d199a264aab962